### PR TITLE
fix: automatically reconnect session stream reads

### DIFF
--- a/apps/mobile/modules/lody-kit/data-runtime/session-read.ts
+++ b/apps/mobile/modules/lody-kit/data-runtime/session-read.ts
@@ -1,0 +1,32 @@
+// Retry reads only. Durable writes and Machine RPC must never use this helper.
+export async function retrySessionRead<T>(
+  signal: AbortSignal,
+  read: () => Promise<T>,
+  onRetry: (error: unknown) => void,
+): Promise<T> {
+  let delay = 1000;
+  for (;;) {
+    signal.throwIfAborted();
+    try {
+      const result = await read();
+      signal.throwIfAborted();
+      return result;
+    } catch (error) {
+      signal.throwIfAborted();
+      onRetry(error);
+      signal.throwIfAborted();
+      await new Promise<void>((resolve, reject) => {
+        const abort = () => {
+          clearTimeout(timer);
+          reject(signal.reason);
+        };
+        const timer = setTimeout(() => {
+          signal.removeEventListener('abort', abort);
+          resolve();
+        }, delay);
+        signal.addEventListener('abort', abort, { once: true });
+      });
+      delay = Math.min(delay * 2, 30000);
+    }
+  }
+}

--- a/apps/mobile/modules/lody-kit/data-runtime/session.ts
+++ b/apps/mobile/modules/lody-kit/data-runtime/session.ts
@@ -4,6 +4,7 @@ import { decompress } from 'fzstd';
 import { decodeFrames, encodeFrame } from '../decoder/frames';
 import { identityAt, itemRev, projectSession } from './project';
 import { machineRpc, type RpcReply } from './machine-rpc';
+import { retrySessionRead } from './session-read';
 export { projectSession } from './project';
 
 type Grant = { token: string; gatewayBaseUrl: string };
@@ -205,17 +206,27 @@ export async function openSession(
   const event = (status: string, reason?: string) => {
     scheduleEmit(state, status, reason);
   };
+  const retrying = (error: unknown) => {
+    state.ready = false;
+    event('syncing', error instanceof Error ? error.message : 'sync_failed');
+  };
   event('syncing');
   void (async () => {
     try {
-      state.client = await clientFor(`${workspace}:s:${id}`, getGrant);
-      controller.signal.throwIfAborted();
-      const initial = await state.client.bootstrap({
-        signal: controller.signal,
-      });
-      if (!initial.ok) throw new Error(initial.result.code);
+      const data = await retrySessionRead(
+        controller.signal,
+        async () => {
+          state.client = await clientFor(`${workspace}:s:${id}`, getGrant);
+          controller.signal.throwIfAborted();
+          const initial = await state.client.bootstrap({
+            signal: controller.signal,
+          });
+          if (!initial.ok) throw new Error(initial.result.code);
+          return initial.result;
+        },
+        retrying,
+      );
       if (sessions.get(id) !== state) return;
-      const data = initial.result;
       let size = 0;
       const consume = (bytes: Uint8Array, snapshot = false) => {
         size += bytes.length;
@@ -241,13 +252,20 @@ export async function openSession(
           event('syncing');
           if (++pages > 100) throw new Error('session_limit');
         }
-        const next = await state.client.readOnce({
-          offset,
-          cursor,
-          signal: controller.signal,
-          ...(upToDate ? { live: 'long-poll' as const } : {}),
-        });
-        if (!next.ok) throw new Error(next.result.code);
+        const next = await retrySessionRead(
+          controller.signal,
+          async () => {
+            const result = await state.client.readOnce({
+              offset,
+              cursor,
+              signal: controller.signal,
+              ...(upToDate ? { live: 'long-poll' as const } : {}),
+            });
+            if (!result.ok) throw new Error(result.result.code);
+            return result;
+          },
+          retrying,
+        );
         if (sessions.get(id) !== state) return;
         if (next.result.payload) {
           consume(next.result.payload.body);
@@ -263,6 +281,7 @@ export async function openSession(
           await new Promise((resolve) => setTimeout(resolve, 1000));
       }
     } catch (error) {
+      if (controller.signal.aborted || sessions.get(id) !== state) return;
       state.ready = false;
       event('offline', error instanceof Error ? error.message : 'sync_failed');
     }

--- a/apps/mobile/tests/native/session-read.test.mjs
+++ b/apps/mobile/tests/native/session-read.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { retrySessionRead } from '../../modules/lody-kit/data-runtime/session-read.ts';
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+test('session reads reconnect automatically with capped backoff', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const controller = new AbortController();
+  let attempts = 0;
+  const failures = [];
+  const result = retrySessionRead(
+    controller.signal,
+    async () => {
+      attempts++;
+      if (attempts <= 7) throw new Error('network unavailable');
+      return 'fresh history';
+    },
+    (error) => failures.push(error),
+  );
+  await tick();
+  for (const delay of [1000, 2000, 4000, 8000, 16000, 30000, 30000]) {
+    const before = attempts;
+    t.mock.timers.tick(delay - 1);
+    await tick();
+    assert.equal(attempts, before);
+    t.mock.timers.tick(1);
+    await tick();
+    assert.equal(attempts, before + 1);
+  }
+  assert.equal(await result, 'fresh history');
+  assert.equal(failures.length, 7);
+});
+
+test('stopping a session cancels a pending retry and ignores late reads', async (t) => {
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  const controller = new AbortController();
+  let attempts = 0;
+  const result = retrySessionRead(
+    controller.signal,
+    async () => {
+      attempts++;
+      throw new Error('offline');
+    },
+    () => {},
+  );
+  const rejected = assert.rejects(result, { name: 'AbortError' });
+  await tick();
+  controller.abort();
+  await rejected;
+  t.mock.timers.tick(60000);
+  await tick();
+  assert.equal(attempts, 1);
+
+  const late = new AbortController();
+  let resolve;
+  const pending = retrySessionRead(
+    late.signal,
+    () =>
+      new Promise((done) => {
+        resolve = done;
+      }),
+    () => assert.fail('cancelled reads must not retry'),
+  );
+  late.abort();
+  resolve('stale history');
+  await assert.rejects(pending, { name: 'AbortError' });
+});

--- a/apps/mobile/tests/native/session-runtime.test.mjs
+++ b/apps/mobile/tests/native/session-runtime.test.mjs
@@ -987,9 +987,103 @@ test(
     await new Promise((resolve) => setImmediate(resolve));
     assert.equal(
       bootstraps.length,
-      before + 1,
-      'opening an offline retained Session retries bootstrap',
+      before,
+      'opening a reconnecting Session reuses its automatic retry',
     );
+  },
+);
+
+test(
+  'session bootstrap and stream reads recover without another watch or writes',
+  { timeout: 8000 },
+  async (t) => {
+    let bootstraps = 0;
+    const reads = [];
+    const events = [];
+    const history = new LoroDoc();
+    let recovered;
+    const recovery = new Promise((resolve) => {
+      recovered = resolve;
+    });
+    globalThis.__sessionClient = class {
+      async bootstrap() {
+        if (++bootstraps === 1) throw new Error('network unavailable');
+        return {
+          ok: true,
+          result: {
+            snapshotOffset: '7',
+            snapshot: { body: history.export({ mode: 'snapshot' }) },
+            updates: [],
+            nextOffset: '7',
+            cursor: 'cursor-7',
+            upToDate: true,
+          },
+        };
+      }
+      async readOnce(request) {
+        reads.push({ offset: request.offset, cursor: request.cursor });
+        if (reads.length === 1)
+          return { ok: false, result: { code: 'network_error' } };
+        if (reads.length === 2)
+          return {
+            ok: true,
+            result: {
+              nextOffset: '8',
+              cursor: 'cursor-8',
+              upToDate: true,
+              closed: false,
+            },
+          };
+        recovered();
+        return new Promise((resolve, reject) => {
+          request.signal.addEventListener(
+            'abort',
+            () => reject(request.signal.reason),
+            { once: true },
+          );
+        });
+      }
+      append() {
+        assert.fail('read recovery must never append');
+      }
+    };
+    const runtime = await loadRuntime();
+    runtime.appendUserTurn(
+      history,
+      'saved-turn',
+      'Existing message',
+      'u1',
+      {},
+      '2026-09-11T00:00:00Z',
+    );
+    t.after(() => {
+      runtime.stopSessions();
+      delete globalThis.__sessionClient;
+    });
+    await runtime.openSession(
+      'recovery',
+      'w1',
+      async () => ({
+        token: 'synthetic',
+        gatewayBaseUrl: 'https://x.invalid',
+      }),
+      (event) => events.push(JSON.parse(event.session)),
+      async () => {
+        assert.fail('read recovery must never dispatch');
+      },
+    );
+    await recovery;
+    assert.equal(bootstraps, 2);
+    assert.deepEqual(reads, [
+      { offset: '7', cursor: 'cursor-7' },
+      { offset: '7', cursor: 'cursor-7' },
+      { offset: '8', cursor: 'cursor-8' },
+    ]);
+    assert.equal(events.at(-1).status, 'live');
+    const firstLive = events.find((event) => event.status === 'live');
+    assert.equal(firstLive.entries.length, 1);
+    assert.deepEqual(events.at(-1).entries, firstLive.entries);
+    assert.ok(events.every((event) => event.status !== 'offline'));
   },
 );
 


### PR DESCRIPTION
Session synchronization previously stopped after a failed bootstrap or Streams read and required tapping the composer notice to resume. Retry authorization/bootstrap and subsequent reads automatically with exponential backoff from 1 second to a maximum interval of 30 seconds, keeping the session in syncing state until it recovers.

Retain the existing history and read cursor during read retries, cancel retries when the session is stopped or evicted, and ignore late results after cancellation. Retries apply only to reads; durable writes and Machine RPC are never replayed. Data limits, stalled cursors, and closed streams still stop synchronization.

Validation: the two retry/backoff and cancellation unit tests passed, and git diff --check passed. Added a session-runtime regression test for bootstrap/read recovery, retained history and cursors, and absence of writes; updated the retained-session expectation to reuse automatic recovery. The full session-runtime tests, pnpm check, and pnpm bundle remain unverified because dependency downloads failed (including loro-crdt). No simulator end-to-end verification or acceptance evidence is available.